### PR TITLE
修正依赖项fpdf为fpdf2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ browser-cookie3
 pysqlite3
 Markdown
 EbookLib
-fpdf
+fpdf2
 beautifulsoup4


### PR DESCRIPTION
有一些功能譬如`set_margins`是`fpdf2`才有的，用`fpdf`会报错。

抱歉之前本地跑的时候没有意识到，换了新环境才发现。